### PR TITLE
Feature: Multiple Webhooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Soon.
 
 | Version | Changes |
 | :------ | :------ |
+| 2.1.0 | [FEATURE] Multiple Webhooks
 | 2.0.7 | [HOTFIX] Fixed WooCommerce order not showing products.<br>[FEATURE] Added Contact Form 7 integration. |
 | 2.0.6 | [HOTFIX] Fixed CPT notification being fired for unwanted CPT. |
 | 2.0.5 | [FEATURE] On post type update the user who updated will be displayed on the notification. |

--- a/__src/js/admin-scripts.js
+++ b/__src/js/admin-scripts.js
@@ -47,7 +47,7 @@
 	} );
 
 	// Handle integration test notification.
-	$( '.slack_test_integration' ).on( 'click', function ( e ) {
+	$( '.webhooks-wrapper' ).on( 'click', '.slack_test_integration', function( e ) {
 		e.preventDefault();
 
 		var _btn = $( this );
@@ -55,12 +55,16 @@
 
 		_btn.removeClass( 'testing ok error' ).addClass( 'testing' );
 
+		var _wrapper = _btn.closest('.notification-form');
+		_url_field = _wrapper.find('input[name^="webhooks[url]"]');
+
 		$.ajax( {
 			url: ajaxurl,
 			method: 'POST',
 			dataType: 'json',
 			data: {
-				action: 'slack-test-integration'
+				action: 'slack-test-integration',
+				webhook_url: _url_field.val(),
 			},
 			success: function ( response ) {
 
@@ -93,6 +97,20 @@
 
 	} );
 
+	// Handle new webhook button link
+	$( 'a.page-title-action[href="#new_webhook"]' ).on( 'click', function ( e ) {
+		e.preventDefault();
+
+		var _box = $( '#webhook_box' ).html();
+
+		var _newBox = $( _box ).clone();
+
+		_newBox.appendTo( '.webhooks-wrapper' );
+		_newBox.find( '.notification-settings' ).slideToggle();
+		_newBox.toggleClass( 'open' );
+
+	} );
+
 	// Handle notifications collapsible action.
 	$( document ).on( 'click', '.notification-box .notification-header', function ( e ) {
 		e.preventDefault();
@@ -101,6 +119,13 @@
 		$( this ).parent( '.notification-box' ).toggleClass( 'open' );
 
 	} );
+
+	// Open new notification-boxes (only when there are no webhooks)
+	$( '.notification-box.new' ).each( function () {
+		$( this ).find( '.notification-settings' ).slideToggle();
+		$( this ).toggleClass( 'open' );
+
+	});
 
 	// Handle notification type switch
 	$( document ).on( 'change', '.notification-box select', function () {

--- a/__src/scss/admin-styles.scss
+++ b/__src/scss/admin-styles.scss
@@ -93,7 +93,8 @@
 		}
 	}
 
-	.notifications-wrapper {
+	.notifications-wrapper,
+	.webhooks-wrapper {
 		margin-top: 16px;
 
 		.notification-box {

--- a/core/class-admin.php
+++ b/core/class-admin.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.0
- * @version     2.0.6
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications;
@@ -78,6 +78,7 @@ class Admin {
 		do_action( 'slack_before_register_pages' );
 
 		new Settings\General();
+		new Settings\Webhooks();
 		new Settings\Notifications();
 		new Settings\Support();
 

--- a/core/class-ajax.php
+++ b/core/class-ajax.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.0
- * @version     2.0.6
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications;
@@ -48,7 +48,12 @@ class AJAX {
 
 		$message = __( ':pizza: Mmmmmmm.... Pizzzzzzzzzzzzzzzzzzzzzzza!!!', 'dorzki-notifications-to-slack' );
 
-		$sent = $bot->send_message( $message );
+		$args = [];
+		if ( !empty( $_POST ) && $_POST[ 'webhook_url' ] ) {
+			$args['webhook_url'] = $_POST['webhook_url'];
+		}
+
+		$sent = $bot->send_message( $message, [], $args );
 
 		return ( $sent ) ? wp_send_json_success() : wp_send_json_error();
 

--- a/core/class-plugin.php
+++ b/core/class-plugin.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.0
- * @version     2.0.7
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications;
@@ -111,9 +111,11 @@ class Plugin {
 		include_once 'settings/class-field.php';
 		include_once 'settings/class-settings-page.php';
 		include_once 'settings/class-general.php';
+		include_once 'settings/class-webhooks.php';
 		include_once 'settings/class-notifications.php';
 		include_once 'settings/class-support.php';
 
+		include_once 'class-webhook.php';
 		include_once 'class-logger.php';
 		include_once 'class-slack-bot.php';
 		include_once 'class-ajax.php';
@@ -143,6 +145,8 @@ class Plugin {
 		new Notifications\Contact_Form_7();
 
 		new AJAX();
+
+		new Webhook();
 
 		do_action( 'slack_after_init_classes' );
 

--- a/core/class-webhook.php
+++ b/core/class-webhook.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Webhook class.
+ *
+ * @package     Slack_Notifications
+ * @subpackage  Webhook
+ * @author      Yoavi Matchulsky <y@yoavi.codes>
+ * @link        https://yoavi.codes
+ * @since       2.1.0
+ * @version     2.1.0
+ */
+
+namespace Slack_Notifications;
+
+// Block direct access to the file via url.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+
+/**
+ * Class Webhook
+ *
+ * @package Slack_Notifications
+ */
+class Webhook {
+
+	/**
+	 * Database field name.
+	 *
+	 * @var string
+	 */
+	protected static $db_field;
+
+	/* ------------------------------------------ */
+
+
+	/**
+	 * Notification_Type constructor.
+	 */
+	public function __construct() {
+
+		self::$db_field = SLACK_NOTIFICATIONS_FIELD_PREFIX . 'webhooks';
+
+		$webhooks = self::get_webhooks();
+		$GLOBALS['slack_webhooks'] = $webhooks or [];
+
+	}
+
+
+	/* ------------------------------------------ */
+
+
+	/**
+	 * Retrieve webhooks from the database.
+	 *
+	 * @return array|mixed|object
+	 */
+	public static function get_webhooks() {
+
+		return json_decode( get_option( self::$db_field ) );
+
+	}
+
+	/**
+	 * Retrieve webhooks from the database.
+	 *
+	 * @return array|mixed|object
+	 */
+	public static function get_webhook( $webhook_id ) {
+
+		$webhooks = self::get_webhooks();
+
+		foreach ( $webhooks as $webhook ) {
+			if ( $webhook->id === $webhook_id ) {
+				return $webhook;
+			}
+		}
+
+		return false;
+
+	}
+
+	public static function save_webhooks( $post_data ) {
+
+		$webhooks = [];
+
+		foreach ( $post_data['id'] as $index => $webhook_id ) {
+
+			$title = $post_data['title'][$index];
+			$url   = $post_data['url'][$index];
+
+			if ( empty( $url ) ) {
+				continue;
+			}
+
+			if ( empty( $title ) ) {
+				$title = __( 'New Webhook', 'dorzki-notifications-to-slack' );
+			}
+
+			// Saving a new webhook with a random id
+			if ( empty( $webhook_id ) ) {
+				$webhook_id = self::random_id();
+			}
+
+			$webhooks[] = [
+				'id'    => $webhook_id,
+				'title' => $title,
+				'url'   => $url,
+			];
+
+		}
+
+		return update_option( self::$db_field, json_encode( $webhooks ) );
+
+	}
+
+	public static function random_id() {
+
+		if ( version_compare( PHP_VERSION, '7' ) >= 0 ) {
+			return bin2hex(random_bytes(16));
+		}
+		else {
+			return uniqid();
+		}
+
+	}
+}

--- a/core/notifications/class-comment.php
+++ b/core/notifications/class-comment.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.0
- * @version     2.0.6
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications\Notifications;
@@ -96,7 +96,7 @@ class Comment extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -104,6 +104,7 @@ class Comment extends Notification_Type {
 			[
 				'color'   => '#e67e22',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 

--- a/core/notifications/class-contact-form-7.php
+++ b/core/notifications/class-contact-form-7.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.7
- * @version     2.0.7
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications\Notifications;
@@ -122,7 +122,7 @@ class Contact_Form_7 extends Notification_Type {
 		$message = __( ':incoming_envelope: *%1$s* was submitted on *<%2$s|%3$s>*!', 'dorzki-notifications-to-slack' );
 		$message = sprintf( $message, $cf7->title(), get_bloginfo( 'url' ), get_bloginfo( 'name' ) );
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -130,6 +130,7 @@ class Contact_Form_7 extends Notification_Type {
 			[
 				'color'   => '#f39c12',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 

--- a/core/notifications/class-cpt.php
+++ b/core/notifications/class-cpt.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.0
- * @version     2.0.6
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications\Notifications;
@@ -221,7 +221,7 @@ class CPT extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -229,6 +229,7 @@ class CPT extends Notification_Type {
 			[
 				'color'   => '#9b59b6',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -282,7 +283,7 @@ class CPT extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -290,6 +291,7 @@ class CPT extends Notification_Type {
 			[
 				'color'   => '#8e44ad',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -338,7 +340,7 @@ class CPT extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -346,6 +348,7 @@ class CPT extends Notification_Type {
 			[
 				'color'   => '#8e44ad',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -396,7 +399,7 @@ class CPT extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -404,6 +407,7 @@ class CPT extends Notification_Type {
 			[
 				'color'   => '#8e44ad',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -455,7 +459,7 @@ class CPT extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -463,6 +467,7 @@ class CPT extends Notification_Type {
 			[
 				'color'   => '#e74c3c',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 

--- a/core/notifications/class-notification-type.php
+++ b/core/notifications/class-notification-type.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.0
- * @version     2.0.6
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications\Notifications;
@@ -90,10 +90,12 @@ class Notification_Type {
 		// Build notification_id => channel array.
 		$notifications        = self::get_notifications();
 		$this->notif_channels = [];
+		$this->notif_webhooks = [];
 
 		if ( ! empty( $notifications ) ) {
 			foreach ( $notifications as $notification ) {
 				$this->notif_channels[ $notification->action ] = $notification->channel;
+				$this->notif_webhooks[ $notification->action ] = $notification->webhook_id;
 			}
 		}
 
@@ -174,6 +176,26 @@ class Notification_Type {
 		}
 
 		return false;
+
+	}
+
+	protected function get_notification_webhook_data( $func_name ) {
+
+		foreach ( $this->object_options as $notif_id => $notif_data ) {
+
+			foreach ( $notif_data['hooks'] as $func ) {
+
+				if ( $func === $func_name ) {
+
+					$webhook_id = apply_filters( 'slack_notification_webhook_id', $this->notif_webhooks[ $notif_id ], $func_name );
+					$channel = apply_filters( 'slack_notification_channel', $this->notif_channels[ $notif_id ], $func_name );
+
+					return [ $webhook_id, $channel ];
+				}
+			}
+		}
+
+		return null;
 
 	}
 

--- a/core/notifications/class-page.php
+++ b/core/notifications/class-page.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.0
- * @version     2.0.6
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications\Notifications;
@@ -125,7 +125,7 @@ class Page extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -133,6 +133,7 @@ class Page extends Notification_Type {
 			[
 				'color'   => '#3498db',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -179,7 +180,7 @@ class Page extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -187,6 +188,7 @@ class Page extends Notification_Type {
 			[
 				'color'   => '#2980b9',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -228,7 +230,7 @@ class Page extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -236,6 +238,7 @@ class Page extends Notification_Type {
 			[
 				'color'   => '#2980b9',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -280,7 +283,7 @@ class Page extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -288,6 +291,7 @@ class Page extends Notification_Type {
 			[
 				'color'   => '#2980b9',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -332,7 +336,7 @@ class Page extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -340,6 +344,7 @@ class Page extends Notification_Type {
 			[
 				'color'   => '#e74c3c',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 

--- a/core/notifications/class-post.php
+++ b/core/notifications/class-post.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.0
- * @version     2.0.6
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications\Notifications;
@@ -172,7 +172,7 @@ class Post extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -180,6 +180,7 @@ class Post extends Notification_Type {
 			[
 				'color'   => '#3498db',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -236,7 +237,7 @@ class Post extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -244,6 +245,7 @@ class Post extends Notification_Type {
 			[
 				'color'   => '#2980b9',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -295,7 +297,7 @@ class Post extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -303,6 +305,7 @@ class Post extends Notification_Type {
 			[
 				'color'   => '#2980b9',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -357,7 +360,7 @@ class Post extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -365,6 +368,7 @@ class Post extends Notification_Type {
 			[
 				'color'   => '#2980b9',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -419,7 +423,7 @@ class Post extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -427,6 +431,7 @@ class Post extends Notification_Type {
 			[
 				'color'   => '#e74c3c',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 

--- a/core/notifications/class-system.php
+++ b/core/notifications/class-system.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.0
- * @version     2.0.6
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications\Notifications;
@@ -110,7 +110,7 @@ class System extends Notification_Type {
 
 			];
 
-			$channel = $this->get_notification_channel( __FUNCTION__ );
+			[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 			return $this->slack_bot->send_message(
 				$message,
@@ -118,6 +118,7 @@ class System extends Notification_Type {
 				[
 					'color'   => '#f1c40f',
 					'channel' => $channel,
+					'webhook_id' => $webhook_id,
 				]
 			);
 
@@ -195,7 +196,7 @@ class System extends Notification_Type {
 
 			$attachments['multiple'] = true;
 
-			$channel = $this->get_notification_channel( __FUNCTION__ );
+			[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 			return $this->slack_bot->send_message(
 				$message,
@@ -203,6 +204,7 @@ class System extends Notification_Type {
 				[
 					'color'   => '#f1c40f',
 					'channel' => $channel,
+					'webhook_id' => $webhook_id,
 				]
 			);
 
@@ -280,7 +282,7 @@ class System extends Notification_Type {
 
 			$attachments['multiple'] = true;
 
-			$channel = $this->get_notification_channel( __FUNCTION__ );
+			[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 			return $this->slack_bot->send_message(
 				$message,
@@ -288,6 +290,7 @@ class System extends Notification_Type {
 				[
 					'color'   => '#f1c40f',
 					'channel' => $channel,
+					'webhook_id' => $webhook_id,
 				]
 			);
 

--- a/core/notifications/class-user.php
+++ b/core/notifications/class-user.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.0
- * @version     2.0.6
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications\Notifications;
@@ -125,7 +125,7 @@ class User extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -133,6 +133,7 @@ class User extends Notification_Type {
 			[
 				'color'   => '#2ecc71',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -171,7 +172,7 @@ class User extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -179,6 +180,7 @@ class User extends Notification_Type {
 			[
 				'color'   => '#27ae60',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -224,7 +226,7 @@ class User extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -232,6 +234,7 @@ class User extends Notification_Type {
 			[
 				'color'   => '#e74c3c',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 

--- a/core/notifications/class-woocommerce.php
+++ b/core/notifications/class-woocommerce.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.0
- * @version     2.0.6
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications\Notifications;
@@ -225,7 +225,7 @@ class WooCommerce extends Notification_Type {
 
 		$attachments = $this->build_order_attachments( $order );
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -233,6 +233,7 @@ class WooCommerce extends Notification_Type {
 			[
 				'color'   => '#34495e',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -262,7 +263,7 @@ class WooCommerce extends Notification_Type {
 
 		$attachments = $this->build_order_attachments( $order );
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -270,6 +271,7 @@ class WooCommerce extends Notification_Type {
 			[
 				'color'   => '#2c3e50',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -325,7 +327,7 @@ class WooCommerce extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -333,6 +335,7 @@ class WooCommerce extends Notification_Type {
 			[
 				'color'   => '#2c3e50',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 
@@ -387,7 +390,7 @@ class WooCommerce extends Notification_Type {
 			],
 		];
 
-		$channel = $this->get_notification_channel( __FUNCTION__ );
+		[ $webhook_id, $channel ] = $this->get_notification_webhook_data( __FUNCTION__ );
 
 		return $this->slack_bot->send_message(
 			$message,
@@ -395,6 +398,7 @@ class WooCommerce extends Notification_Type {
 			[
 				'color'   => '#2c3e50',
 				'channel' => $channel,
+				'webhook_id' => $webhook_id,
 			]
 		);
 

--- a/core/settings/class-general.php
+++ b/core/settings/class-general.php
@@ -7,7 +7,7 @@
  * @author      Dor Zuberi <webmaster@dorzki.co.il>
  * @link        https://www.dorzki.co.il
  * @since       2.0.0
- * @version     2.0.6
+ * @version     2.1.0
  */
 
 namespace Slack_Notifications\Settings;
@@ -55,10 +55,6 @@ class General extends Settings_Page {
 					'title'  => __( 'Slack Integration', 'dorzki-notifications-to-slack' ),
 					'desc'   => __( 'Setup integration between WordPress and Slack.' ),
 					'fields' => [
-						'webhook'          => [
-							'label' => esc_html__( 'Webhook URL', 'dorzki-notifications-to-slack' ),
-							'type'  => Field::INPUT_TEXT,
-						],
 						'default_channel'  => [
 							'label' => esc_html__( 'Default Channel', 'dorzki-notifications-to-slack' ),
 							'type'  => Field::INPUT_TEXT,
@@ -70,10 +66,6 @@ class General extends Settings_Page {
 						'bot_image'        => [
 							'label' => esc_html__( 'Bot Image', 'dorzki-notifications-to-slack' ),
 							'type'  => Field::INPUT_MEDIA,
-						],
-						'test_integration' => [
-							'label' => esc_html__( 'Test Integration', 'dorzki-notifications-to-slack' ),
-							'type'  => Field::INPUT_TEST,
 						],
 					],
 				],

--- a/core/settings/class-webhooks.php
+++ b/core/settings/class-webhooks.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Webhooks settings screen.
+ *
+ * @package     Slack_Notifications\Webhooks
+ * @subpackage  Webhooks
+ * @author      Yoavi Matchulsky <y@yoavi.codes>
+ * @link        https://yoavi.codes
+ * @since       2.1.0
+ * @version     2.1.0
+ */
+
+namespace Slack_Notifications\Settings;
+
+// Block direct access to the file via url.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+
+/**
+ * Class Webhooks
+ *
+ * @package Slack_Notifications\Webhooks
+ */
+class Webhooks extends Settings_Page {
+
+	/**
+	 * Webhooks constructor.
+	 */
+	public function __construct() {
+
+		$this->page_title    = __( 'Webhooks', 'dorzki-notifications-to-slack' );
+		$this->menu_title    = __( 'Webhooks', 'dorzki-notifications-to-slack' );
+		$this->page_slug     = 'webhooks';
+		$this->template_page = 'settings-webhooks';
+		$this->header_link   = [
+			'label' => esc_html__( 'Add New', 'dorzki-notifications-to-slack' ),
+			'link'  => '#new_webhook',
+		];
+
+		parent::__construct();
+
+	}
+
+}

--- a/readme.txt
+++ b/readme.txt
@@ -63,6 +63,9 @@ Please feel free to contact me `webmaster[AT]dorzki.co.il`
 
 == Changelog ==
 
+= 2.1.0 =
+* [FEATURE] Multiple Webhooks
+
 = 2.0.7 =
 * [HOTFIX] Fixed WooCommerce order not showing products.
 * [FEATURE] Added Contact Form 7 integration.

--- a/slack-notifications.php
+++ b/slack-notifications.php
@@ -3,14 +3,14 @@
  * Plugin Name: Slack Notifications
  * Plugin URI: https://www.dorzki.co.il
  * Description: Stay up-to-date about your WordPress site directly to your Slack.
- * Version: 2.0.7
+ * Version: 2.1.0
  * Author: dorzki
  * Author URI: https://www.dorzki.co.il
  * Text Domain: dorzki-notifications-to-slack
  *
  * @package Slack_Notifications
  * @since   1.0.0
- * @version 2.0.7
+ * @version 2.1.0
  * @author  Dor Zuberi <me@dorzki.co.il>
  * @link    https://www.dorzki.co.il
  */
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Define plugins constants.
-define( 'SLACK_NOTIFICATIONS_VERSION', '2.0.7' );
+define( 'SLACK_NOTIFICATIONS_VERSION', '2.1.0' );
 define( 'SLACK_NOTIFICATIONS_SLUG', 'slack-notifications' );
 define( 'SLACK_NOTIFICATIONS_FIELD_PREFIX', 'slack_' );
 define( 'SLACK_NOTIFICATIONS_PATH', plugin_dir_path( __FILE__ ) );
@@ -77,7 +77,7 @@ function sn_php_version_not_supported() {
 function sn_wp_version_no_supported() {
 
 	/* translators: %s: WordPress version */
-	$notice      = sprintf( esc_html__( 'Slack Notifications plugin requires WordPress version %s or above to work properly.', 'dorzki-notifications-to-slac' ), '4.7' );
+	$notice      = sprintf( esc_html__( 'Slack Notifications plugin requires WordPress version %s or above to work properly.', 'dorzki-notifications-to-slack' ), '4.7' );
 	$notice_html = sprintf( '<div class="error">%s</div>', wpautop( $notice ) );
 
 	echo wp_kses_post( $notice_html );
@@ -95,11 +95,21 @@ function sn_update_plugin_db() {
 	// Get previous version.
 	$old_version = get_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'version' );
 
+	// Update version to 2.0.0
+	if ( empty ( $old_version ) || version_compare( $old_version, '2.0.0', '<' ) ) {
+		sn_update_plugin_db_200();
+	}
+
+	// Update version to 2.1.0
+	if ( empty ( $old_version ) || version_compare( $old_version, '2.1.0', '<' ) ) {
+		sn_update_plugin_db_210();
+	}
+
 	update_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'version', SLACK_NOTIFICATIONS_VERSION );
 
-	if ( ! empty( $old_version ) && version_compare( $old_version, '2.0.0', '>=' ) ) {
-		return false;
-	}
+}
+
+function sn_update_plugin_db_200() {
 
 	$webhook   = get_option( 'slack_webhook_endpoint' );
 	$channel   = get_option( 'slack_channel_name' );
@@ -261,6 +271,44 @@ function sn_update_plugin_db() {
 	update_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'bot_image', $bot_image );
 	update_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'test_integration', '1' );
 	update_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'notifications', wp_json_encode( $notifications ) );
+
+	return true;
+
+}
+
+/**
+ * Update a single webhook to the new `webhooks` option and update
+ * all previous notifications to use the new webhook
+ */
+function sn_update_plugin_db_210() {
+
+	$webhook = get_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'webhook' );
+	$notifications = json_decode( get_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'notifications' ) );
+
+	if ( empty( $webhook ) ) {
+		return false;
+	}
+
+	// Create a new webhook from the previously defined webhook
+	$webhook_id = Slack_Notifications\Webhook::random_id();
+	$webhooks = [];
+	$webhooks[] = [
+		'id' => $webhook_id,
+		'title' => __( 'Default Webhook', 'dorzki-notifications-to-slack' ),
+		'url' => $webhook,
+	];
+
+	// Update all notifications to use the new webhook
+	foreach ($notifications as $i => $notification) {
+		$notifications[$i]->webhook_id = $webhook_id;
+	}
+
+	// Delete previous webhook option
+	delete_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'webhook' );
+
+	update_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'webhooks', wp_json_encode( $webhooks ) );
+	update_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'notifications', wp_json_encode( $notifications ) );
+
 
 	return true;
 

--- a/templates/partials/notification.php
+++ b/templates/partials/notification.php
@@ -1,6 +1,6 @@
 <?php
 $title = __( 'New Notification', 'dorzki-notifications-to-slack' );
-$type  = $action = $channel = null;
+$type  = $action = $channel = $webhook_id = null;
 
 if ( isset( $notification ) && is_object( $notification ) ) {
 
@@ -8,6 +8,7 @@ if ( isset( $notification ) && is_object( $notification ) ) {
 	$type    = $notification->type;
 	$action  = $notification->action;
 	$channel = $notification->channel;
+	$webhook_id = $notification->webhook_id;
 
 }
 ?>
@@ -59,6 +60,20 @@ if ( isset( $notification ) && is_object( $notification ) ) {
 						</select>
 
 					<?php endforeach; ?>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Webhook', 'dorzki-notifications-to-slack' ); ?></th>
+				<td>
+
+					<select name="notification[webhook_id][]" class="notification-webhook">
+
+						<?php foreach ( $GLOBALS['slack_webhooks'] as $webhook ) : ?>
+							<option
+									value="<?php echo esc_attr( $webhook->id ); ?>" <?php selected( $webhook_id, $webhook->id ); ?>><?php echo esc_html( $webhook->title ); ?></option>
+						<?php endforeach; ?>
+
+					</select>
 				</td>
 			</tr>
 			<tr>

--- a/templates/partials/webhook.php
+++ b/templates/partials/webhook.php
@@ -1,0 +1,62 @@
+<?php
+
+$title = __( 'New Webhook', 'dorzki-notifications-to-slack' );
+$url = $title = null;
+$new_webhook = ! isset( $webhook );
+
+if ( ! $new_webhook && is_object( $webhook ) ) {
+
+	$id     = $webhook->id;
+	$url  	= $webhook->url;
+	$title  = $webhook->title;
+
+}
+
+?>
+<div class="notification-box <?php echo $new_webhook ? 'new' : null; ?>">
+	<div class="notification-header">
+		<?php if ( $new_webhook ) : ?>
+			<h2><?php _e( 'New Webhook', 'dorzki-notifications-to-slack' ); ?></h2>
+		<?php else : ?>
+			<h2><?php _e( 'Webhook', 'dorzki-notifications-to-slack' ); ?>: <?php echo esc_html( $title ); ?></h2>
+		<?php endif; ?>
+
+		<button class="toggle-content">
+				<span
+					class="screen-reader-text"><?php esc_html_e( 'Toggle Content', 'dorzki-notifications-to-slack' ); ?></span>
+			<span class="toggle-indicator" aria-hidden="true"></span>
+		</button>
+	</div>
+	<div class="notification-settings">
+		<table class="notification-form">
+			<tbody>
+			<tr>
+				<td colspan="2" class="hide">
+					<input type="hidden" name="webhooks[id][<?php echo $id; ?>]"
+						   value="<?php echo esc_attr( $id ); ?>">
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Webhook Title', 'dorzki-notifications-to-slack' ); ?></th>
+				<td><input type="text" class="regular-text" name="webhooks[title][<?php echo $id; ?>]"
+						   value="<?php echo esc_attr( $title ); ?>">
+				</td>
+			</tr>
+			<tr>
+				<th scope="row"><?php esc_html_e( 'Webhook Url', 'dorzki-notifications-to-slack' ); ?></th>
+				<td><input type="text" class="regular-text" name="webhooks[url][<?php echo $id; ?>]"
+						   value="<?php echo esc_attr( $url ); ?>">
+				</td>
+			</tr>
+			<tr>
+				<td colspan="2" class="remove-button">
+					<button type="button" class="slack_test_integration button"><?php _e( 'Run Test', 'dorzki-notifications-to-slack' ); ?></button>
+
+					<button type="button"
+							class="remove-notification button"><?php esc_attr_e( 'Remove', 'dorzki-notifications-to-slack' ); ?></button>
+				</td>
+			</tr>
+			</tbody>
+		</table>
+	</div>
+</div>

--- a/templates/settings-notifications.php
+++ b/templates/settings-notifications.php
@@ -11,6 +11,7 @@ if ( isset( $_POST['save_notifications'] ) ) {
 			'action'  => $_POST['notification']['action'][ $notification_type ][ $notification_id ],
 			'channel' => $_POST['notification']['channel'][ $notification_id ],
 			'title'   => $_POST['notification']['title'][ $notification_id ],
+			'webhook_id' => $_POST['notification']['webhook_id'][ $notification_id ],
 		];
 
 	}

--- a/templates/settings-webhooks.php
+++ b/templates/settings-webhooks.php
@@ -1,0 +1,43 @@
+<?php use Slack_Notifications\Webhook;
+
+if ( isset( $_POST['save_webhooks'] ) ) {
+
+	Webhook::save_webhooks( $_POST[ 'webhooks' ] );
+
+}
+
+?>
+
+<form method="post">
+
+	<div class="webhooks-wrapper">
+
+		<!-- Webhook Template -->
+		<template id="webhook_box">
+
+			<?php require SLACK_NOTIFICATIONS_PATH . 'templates/partials/webhook.php'; ?>
+
+		</template>
+		<!-- Webhook Template -->
+
+		<?php $webhooks = Webhook::get_webhooks(); ?>
+
+		<?php if ( is_array( $webhooks ) && ! empty( $webhooks ) ) : ?>
+
+			<?php foreach ( $webhooks as $webhook ) : ?>
+
+				<?php include SLACK_NOTIFICATIONS_PATH . 'templates/partials/webhook.php'; ?>
+
+			<?php endforeach; ?>
+
+		<?php else : ?>
+
+			<?php include SLACK_NOTIFICATIONS_PATH . 'templates/partials/webhook.php'; ?>
+
+		<?php endif; ?>
+
+	</div>
+
+	<input type="submit" name="save_webhooks" id="submit" class="button button-primary"
+		   value="<?php esc_html_e( 'Save Webhooks', 'dorzki-notifications-to-slack' ); ?>">
+</form>

--- a/uninstall.php
+++ b/uninstall.php
@@ -22,6 +22,7 @@ delete_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'default_channel' );
 delete_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'bot_name' );
 delete_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'bot_image' );
 delete_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'text_integration' );
+delete_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'webhooks' );
 delete_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'notifications' );
 delete_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'wordpress_version' );
 delete_option( SLACK_NOTIFICATIONS_FIELD_PREFIX . 'plugins_version' );


### PR DESCRIPTION
This feature will allow adding multiple webhooks and lets
each notification use a different webhook.

`Slack` updated their custom integration and now you can only
create a Slack App with Incoming Webhook to a single channel.
That means that each channel now needs a specific webhook.

Add a new Webhooks settings page to manage all the webhooks
(add, delete and test). Each webhook will have a uniquly
generated id, a display title and a url (Channel is no
longer needed).

handles getting (#get_webhooks) and updating webhooks (#save_webhooks)
and a #random_id helper

The bot instance will now hold all the available webhooks,
and will use it when sending a message. The notifications
now needs to send additional "webhook_id" arg, or
"webhook_url" (used for testing)
* Add #get_webhook_url helper
* If no webhook is found, log an error

Keep track of all the webhooks by the notification action in
NotificationType base class (as $notif_webhooks), and use it
in a new helper #get_notification_webhook_data that returns
both the webhook_id and the channel (for older integrations).
Refactor all the send_message calls in all notification types
to use the new helper and send webhook_id to the bot.
* Add webhook_id select when editing notifications

* Add webhook_url to the $args to test different webhooks
* Move "Run Test" button to the webhooks page

* Fix .slack_test_integration buttons
* Add handler for New Webhook button
* Open new notification-box when there are no other webhooks

Refactor #sn_update_plugin_db to run multiple upgrades.
Refactor the previous upgrade to #sn_update_plugin_db_200
and add new #sn_update_plugin_db_210 helper.

The upgrade for v2.1.0 will take the previous global webhook
and transform it into the new webhooks array, and then
update all the notifications to use the new webhook.